### PR TITLE
Session durations

### DIFF
--- a/app/views/event_sessions/_form.slim
+++ b/app/views/event_sessions/_form.slim
@@ -22,7 +22,7 @@
             = f.label t("enum.event_session.level.#{k}")
 
     .two.fields
-      = f.input :duration, collection: (1..120).to_a.select{ |e| e % 5 == 0 }, as: :select, input_html: { class: 'ui fluid dropdown' }
+      = f.input :duration, collection: [ "Presentation (60 or 45 min incl. Q&A)", "Short talk (20 or 30 minutes incl. Q&A)", "Lightning talk (10 minutes or shorter, incl. Q&A)", "Workshop / tutorial (please specify length in abstract)"], as: :select, input_html: { class: 'ui fluid dropdown' }
 
       = f.input :language, collection: EventSession.languages.keys.to_a, as: :select, selected: 'no', input_html: { class: 'ui fluid dropdown' }, label_method: ->(e) { t("enum.language.#{e}") }
 


### PR DESCRIPTION
Dette tryner antagelig skikkelig (duration er kanskje numerisk?), men sjekker bare inn og oppretter PR for å diskutere.
Jeg har ikke fått testa for klarer ikke kjøre lokalt pga. noe crowd-oppsett.
Dessuten bør sikkert ikke dette gjelde for alle konferanser. Men for KDS ønsker vi ikke at man skal kunne velge flere enn disse.

Trello: https://trello.com/c/IjcMvRQ6/30-bestemte-lengder-p%C3%A5-talks-for-kds
