### PR TITLE
Redirect back to signin and the error message when login-failure

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -20,7 +20,7 @@ class SessionsController < ApplicationController
   end
 
   def failure
-    redirect_to root_url, alert: "Authentication error: #{params[:message].humanize}"
+    redirect_to '/signin', alert: "Authentication error: #{params[:message].humanize}"
   end
 
 protected


### PR DESCRIPTION
https://trello.com/c/pPi6a97u/28-feil-passord-p%C3%A5-loginside-redirecter-deg-tilbake-til-loginside-uten-feilmelding